### PR TITLE
Fix link in webhooks README.md

### DIFF
--- a/webhooks/README.md
+++ b/webhooks/README.md
@@ -2,7 +2,7 @@
 
 ### Overview
 
-This is a starter app that is to be used with the Plaid and Webhooks [YouTube tutorial](https://www.youtube.com/). It implements a very basic version of a Plaid-powered application using HTML/VanillaJS on the front end, and NodeJS/Express on the backend.
+This is a starter app that is to be used with the Plaid and Webhooks [YouTube tutorial](https://www.youtube.com/watch?v=0E0KEAVeDyc). It implements a very basic version of a Plaid-powered application using HTML/VanillaJS on the front end, and NodeJS/Express on the backend.
 
 ### Running the app
 


### PR DESCRIPTION
Currently the link is just for youtube home page, not sure if this intentional or not?