### PR TITLE
Fix dead Node.js install link in tutorial READMEs

### DIFF
--- a/ios-swift/README.md
+++ b/ios-swift/README.md
@@ -18,7 +18,7 @@ git clone https://github.com/plaid/tutorial-resources && cd ios/start
 
 ### Set up your server
 
-The server is designed to be used with Node 16 or higher. For information on installing Node, see [How to install Node.js](https://nodejs.dev/learn/how-to-install-nodejs), and consider using [nvm](https://github.com/nvm-sh/nvm) to easily switch between Node versions.
+The server is designed to be used with Node 16 or higher. For information on installing Node, see [How to install Node.js](https://nodejs.org/en/download), and consider using [nvm](https://github.com/nvm-sh/nvm) to easily switch between Node versions.
 
 #### Move into your server directory
 

--- a/transactions/README.md
+++ b/transactions/README.md
@@ -18,7 +18,7 @@ git clone https://github.com/plaid/tutorial-resources && cd transactions/start
 
 #### Set up your environment
 
-This app is designed to be used with Node 16 or higher. For information on installing Node, see [How to install Node.js](https://nodejs.dev/learn/how-to-install-nodejs), and consider using [nvm](https://github.com/nvm-sh/nvm) to easily switch between Node versions.
+This app is designed to be used with Node 16 or higher. For information on installing Node, see [How to install Node.js](https://nodejs.org/en/download), and consider using [nvm](https://github.com/nvm-sh/nvm) to easily switch between Node versions.
 
 #### Install dependencies
 

--- a/vanilla-js-oauth/README.md
+++ b/vanilla-js-oauth/README.md
@@ -18,7 +18,7 @@ git clone https://github.com/plaid/tutorial-resources && cd vanilla-js-oauth/sta
 
 #### Set up your environment
 
-This app uses the latest stable version of Node. At the time of this writing, that's v16.14.0. It's recommended you use a similar version of Node to run the app. For information on installing Node, see [How to install Node.js](https://nodejs.dev/learn/how-to-install-nodejs), and consider using [nvm](https://github.com/nvm-sh/nvm) to easily switch between Node versions.
+This app uses the latest stable version of Node. At the time of this writing, that's v16.14.0. It's recommended you use a similar version of Node to run the app. For information on installing Node, see [How to install Node.js](https://nodejs.org/en/download), and consider using [nvm](https://github.com/nvm-sh/nvm) to easily switch between Node versions.
 
 #### Install dependencies
 

--- a/webhooks/README.md
+++ b/webhooks/README.md
@@ -18,7 +18,7 @@ git clone https://github.com/plaid/tutorial-resources && cd webhooks/start/
 
 #### Set up your environment
 
-This app uses the latest stable version of Node. At the time of this writing, that's v16.14.2. It's recommended you use a similar version of Node to run the app. For information on installing Node, see [How to install Node.js](https://nodejs.dev/learn/how-to-install-nodejs), and consider using [nvm](https://github.com/nvm-sh/nvm) to easily switch between Node versions.
+This app uses the latest stable version of Node. At the time of this writing, that's v16.14.2. It's recommended you use a similar version of Node to run the app. For information on installing Node, see [How to install Node.js](https://nodejs.org/en/download), and consider using [nvm](https://github.com/nvm-sh/nvm) to easily switch between Node versions.
 
 #### Install dependencies
 


### PR DESCRIPTION
`nodejs.dev` was folded into `nodejs.org` and the `/learn/how-to-install-nodejs` path now 404s, so the "install Node.js" link in the tutorial READMEs is dead. Repoints all occurrences to the current Node.js download page (`https://nodejs.org/en/download`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)