### PR TITLE
Fix iOS clone path and webhooks env filename in READMEs

### DIFF
--- a/ios-swift/README.md
+++ b/ios-swift/README.md
@@ -13,7 +13,7 @@ If you want the most complete instructions for running the app, please follow al
 Clone the tutorial resources repo to your machine and cd into the project's start directory:
 
 ```bash
-git clone https://github.com/plaid/tutorial-resources && cd ios/start
+git clone https://github.com/plaid/tutorial-resources && cd tutorial-resources/ios-swift/start
 ```
 
 ### Set up your server

--- a/webhooks/README.md
+++ b/webhooks/README.md
@@ -30,7 +30,7 @@ npm install
 
 #### Equip the app with credentials
 
-Copy the included **.env.example** to a file called **.env**.
+Copy the included **.env.template** to a file called **.env**.
 
 ```bash
 cp .env.template .env


### PR DESCRIPTION
Two copy-paste-blocking doc errors:

- `ios-swift/README.md`: `cd ios/start` → `cd tutorial-resources/ios-swift/start` (there is no `ios/` directory)
- `webhooks/README.md`: prose said copy `.env.example`, but the only template file present is `.env.template`

🤖 Generated with [Claude Code](https://claude.com/claude-code)