### PR TITLE
Annotate legacy /transactions/get examples and point to /transactions/sync

### DIFF
--- a/vanilla-js-oauth/README.md
+++ b/vanilla-js-oauth/README.md
@@ -4,7 +4,7 @@
 
 This is a starter app that is to be used with the Getting Started with OAuth and JavaScript [YouTube tutorial](https://www.youtube.com/watch?v=E0GwNBFVGik). It implements a very basic version of a Plaid-powered application using HTML/VanillaJS on the front end, and NodeJS/Express on the backend.
 
-> **Note:** This sample fetches transactions with the legacy `/transactions/get` endpoint and the deprecated `category` field. New apps should use [`/transactions/sync`](https://plaid.com/docs/transactions/sync-migration/) with `personal_finance_category` — see the [`transactions`](../transactions) sample and the [Transactions Sync video](https://youtu.be/Pin0-ceDKcI).
+> **Note:** This sample works and correctly demonstrates the OAuth flow — that's the concept it's teaching. For simplicity it fetches transactions with the legacy `/transactions/get` endpoint and the deprecated `category` field. In a production app you would instead use [`/transactions/sync`](https://plaid.com/docs/transactions/sync-migration/) with `personal_finance_category` — see the [`transactions`](../transactions) sample and the [Transactions Sync video](https://youtu.be/Pin0-ceDKcI).
 
 ### Running the app
 

--- a/vanilla-js-oauth/README.md
+++ b/vanilla-js-oauth/README.md
@@ -4,6 +4,8 @@
 
 This is a starter app that is to be used with the Getting Started with OAuth and JavaScript [YouTube tutorial](https://www.youtube.com/watch?v=E0GwNBFVGik). It implements a very basic version of a Plaid-powered application using HTML/VanillaJS on the front end, and NodeJS/Express on the backend.
 
+> **Note:** This sample fetches transactions with the legacy `/transactions/get` endpoint and the deprecated `category` field. New apps should use [`/transactions/sync`](https://plaid.com/docs/transactions/sync-migration/) with `personal_finance_category` — see the [`transactions`](../transactions) sample and the [Transactions Sync video](https://youtu.be/Pin0-ceDKcI).
+
 ### Running the app
 
 If you want the most complete instructions for running the app, please follow along with the video tutorial linked above.

--- a/vanilla-js-oauth/finished/public/js/index.js
+++ b/vanilla-js-oauth/finished/public/js/index.js
@@ -32,7 +32,8 @@ const getTransactions = async function () {
       date: item.date,
       name: item.name,
       amount: `$${item.amount.toFixed(2)}`,
-      // NOTE: `category` is deprecated; prefer `personal_finance_category` (/transactions/sync).
+      // NOTE: `category` still works but is deprecated; a production app would use
+      // `personal_finance_category` (returned by /transactions/sync) instead.
       categories: item.category.join(", "),
     };
   });

--- a/vanilla-js-oauth/finished/public/js/index.js
+++ b/vanilla-js-oauth/finished/public/js/index.js
@@ -33,7 +33,7 @@ const getTransactions = async function () {
       name: item.name,
       amount: `$${item.amount.toFixed(2)}`,
       // NOTE: `category` still works but is deprecated; a production app would use
-      // `personal_finance_category` (returned by /transactions/sync) instead.
+      // `personal_finance_category` instead.
       categories: item.category.join(", "),
     };
   });

--- a/vanilla-js-oauth/finished/public/js/index.js
+++ b/vanilla-js-oauth/finished/public/js/index.js
@@ -32,6 +32,7 @@ const getTransactions = async function () {
       date: item.date,
       name: item.name,
       amount: `$${item.amount.toFixed(2)}`,
+      // NOTE: `category` is deprecated; prefer `personal_finance_category` (/transactions/sync).
       categories: item.category.join(", "),
     };
   });

--- a/vanilla-js-oauth/finished/server.js
+++ b/vanilla-js-oauth/finished/server.js
@@ -101,6 +101,9 @@ app.get("/api/transactions", async (req, res, next) => {
   const startDate = moment().subtract(30, "days").format("YYYY-MM-DD");
   const endDate = moment().format("YYYY-MM-DD");
 
+  // NOTE: /transactions/get is legacy. New apps should use /transactions/sync — see
+  // ../../transactions, https://youtu.be/Pin0-ceDKcI, and
+  // https://plaid.com/docs/transactions/sync-migration/
   const transactionResponse = await client.transactionsGet({
     access_token: access_token,
     start_date: startDate,

--- a/vanilla-js-oauth/finished/server.js
+++ b/vanilla-js-oauth/finished/server.js
@@ -101,9 +101,9 @@ app.get("/api/transactions", async (req, res, next) => {
   const startDate = moment().subtract(30, "days").format("YYYY-MM-DD");
   const endDate = moment().format("YYYY-MM-DD");
 
-  // NOTE: /transactions/get is legacy. New apps should use /transactions/sync — see
-  // ../../transactions, https://youtu.be/Pin0-ceDKcI, and
-  // https://plaid.com/docs/transactions/sync-migration/
+  // NOTE: this works fine for the tutorial, but /transactions/get is legacy. In a production
+  // app you would fetch transactions with /transactions/sync instead — see ../../transactions,
+  // https://youtu.be/Pin0-ceDKcI, and https://plaid.com/docs/transactions/sync-migration/
   const transactionResponse = await client.transactionsGet({
     access_token: access_token,
     start_date: startDate,

--- a/vanilla-js-oauth/start/public/js/index.js
+++ b/vanilla-js-oauth/start/public/js/index.js
@@ -32,7 +32,8 @@ const getTransactions = async function () {
       date: item.date,
       name: item.name,
       amount: `$${item.amount.toFixed(2)}`,
-      // NOTE: `category` is deprecated; prefer `personal_finance_category` (/transactions/sync).
+      // NOTE: `category` still works but is deprecated; a production app would use
+      // `personal_finance_category` (returned by /transactions/sync) instead.
       categories: item.category.join(", "),
     };
   });

--- a/vanilla-js-oauth/start/public/js/index.js
+++ b/vanilla-js-oauth/start/public/js/index.js
@@ -33,7 +33,7 @@ const getTransactions = async function () {
       name: item.name,
       amount: `$${item.amount.toFixed(2)}`,
       // NOTE: `category` still works but is deprecated; a production app would use
-      // `personal_finance_category` (returned by /transactions/sync) instead.
+      // `personal_finance_category` instead.
       categories: item.category.join(", "),
     };
   });

--- a/vanilla-js-oauth/start/public/js/index.js
+++ b/vanilla-js-oauth/start/public/js/index.js
@@ -32,6 +32,7 @@ const getTransactions = async function () {
       date: item.date,
       name: item.name,
       amount: `$${item.amount.toFixed(2)}`,
+      // NOTE: `category` is deprecated; prefer `personal_finance_category` (/transactions/sync).
       categories: item.category.join(", "),
     };
   });

--- a/vanilla-js-oauth/start/server.js
+++ b/vanilla-js-oauth/start/server.js
@@ -100,9 +100,9 @@ app.get("/api/transactions", async (req, res, next) => {
   const startDate = moment().subtract(30, "days").format("YYYY-MM-DD");
   const endDate = moment().format("YYYY-MM-DD");
 
-  // NOTE: /transactions/get is legacy. New apps should use /transactions/sync — see
-  // ../../transactions, https://youtu.be/Pin0-ceDKcI, and
-  // https://plaid.com/docs/transactions/sync-migration/
+  // NOTE: this works fine for the tutorial, but /transactions/get is legacy. In a production
+  // app you would fetch transactions with /transactions/sync instead — see ../../transactions,
+  // https://youtu.be/Pin0-ceDKcI, and https://plaid.com/docs/transactions/sync-migration/
   const transactionResponse = await client.transactionsGet({
     access_token: access_token,
     start_date: startDate,

--- a/vanilla-js-oauth/start/server.js
+++ b/vanilla-js-oauth/start/server.js
@@ -100,6 +100,9 @@ app.get("/api/transactions", async (req, res, next) => {
   const startDate = moment().subtract(30, "days").format("YYYY-MM-DD");
   const endDate = moment().format("YYYY-MM-DD");
 
+  // NOTE: /transactions/get is legacy. New apps should use /transactions/sync — see
+  // ../../transactions, https://youtu.be/Pin0-ceDKcI, and
+  // https://plaid.com/docs/transactions/sync-migration/
   const transactionResponse = await client.transactionsGet({
     access_token: access_token,
     start_date: startDate,

--- a/webhooks/README.md
+++ b/webhooks/README.md
@@ -4,7 +4,7 @@
 
 This is a starter app that is to be used with the Plaid and Webhooks [YouTube tutorial](https://www.youtube.com/watch?v=0E0KEAVeDyc). It implements a very basic version of a Plaid-powered application using HTML/VanillaJS on the front end, and NodeJS/Express on the backend.
 
-> **Note:** This sample fetches transactions with the legacy `/transactions/get` endpoint and demonstrates the legacy `INITIAL_UPDATE` / `HISTORICAL_UPDATE` / `DEFAULT_UPDATE` / `TRANSACTIONS_REMOVED` webhooks. New apps should use [`/transactions/sync`](https://plaid.com/docs/transactions/sync-migration/) with the `SYNC_UPDATES_AVAILABLE` webhook — see the [`transactions`](../transactions) sample and the [Transactions Sync video](https://youtu.be/Pin0-ceDKcI).
+> **Note:** This sample works and correctly demonstrates how to receive and handle Plaid webhooks — that's the concept it's teaching. For simplicity it fetches transactions with the legacy `/transactions/get` endpoint and the legacy transactions webhooks (`INITIAL_UPDATE` / `HISTORICAL_UPDATE` / `DEFAULT_UPDATE` / `TRANSACTIONS_REMOVED`). In a production app you would instead use [`/transactions/sync`](https://plaid.com/docs/transactions/sync-migration/) with the `SYNC_UPDATES_AVAILABLE` webhook — see the [`transactions`](../transactions) sample and the [Transactions Sync video](https://youtu.be/Pin0-ceDKcI).
 
 ### Running the app
 

--- a/webhooks/README.md
+++ b/webhooks/README.md
@@ -4,6 +4,8 @@
 
 This is a starter app that is to be used with the Plaid and Webhooks [YouTube tutorial](https://www.youtube.com/watch?v=0E0KEAVeDyc). It implements a very basic version of a Plaid-powered application using HTML/VanillaJS on the front end, and NodeJS/Express on the backend.
 
+> **Note:** This sample fetches transactions with the legacy `/transactions/get` endpoint and demonstrates the legacy `INITIAL_UPDATE` / `HISTORICAL_UPDATE` / `DEFAULT_UPDATE` / `TRANSACTIONS_REMOVED` webhooks. New apps should use [`/transactions/sync`](https://plaid.com/docs/transactions/sync-migration/) with the `SYNC_UPDATES_AVAILABLE` webhook — see the [`transactions`](../transactions) sample and the [Transactions Sync video](https://youtu.be/Pin0-ceDKcI).
+
 ### Running the app
 
 If you want the most complete instructions for running the app, please follow along with the video tutorial linked above.

--- a/webhooks/finished/public/js/index.js
+++ b/webhooks/finished/public/js/index.js
@@ -42,6 +42,7 @@ const getTransactions = async function () {
     return {
       date: t.date,
       vendor: t.name,
+      // NOTE: `category` is deprecated; prefer `personal_finance_category` (/transactions/sync).
       category: t.category[0],
       amount: `$${t.amount.toFixed(2)}`,
     };

--- a/webhooks/finished/public/js/index.js
+++ b/webhooks/finished/public/js/index.js
@@ -43,7 +43,7 @@ const getTransactions = async function () {
       date: t.date,
       vendor: t.name,
       // NOTE: `category` still works but is deprecated; a production app would use
-      // `personal_finance_category` (returned by /transactions/sync) instead.
+      // `personal_finance_category` instead.
       category: t.category[0],
       amount: `$${t.amount.toFixed(2)}`,
     };

--- a/webhooks/finished/public/js/index.js
+++ b/webhooks/finished/public/js/index.js
@@ -42,7 +42,8 @@ const getTransactions = async function () {
     return {
       date: t.date,
       vendor: t.name,
-      // NOTE: `category` is deprecated; prefer `personal_finance_category` (/transactions/sync).
+      // NOTE: `category` still works but is deprecated; a production app would use
+      // `personal_finance_category` (returned by /transactions/sync) instead.
       category: t.category[0],
       amount: `$${t.amount.toFixed(2)}`,
     };

--- a/webhooks/finished/server.js
+++ b/webhooks/finished/server.js
@@ -155,6 +155,9 @@ app.get("/server/transactions", async (req, res, next) => {
     const startDate = moment().subtract(30, "days").format("YYYY-MM-DD");
     const endDate = moment().format("YYYY-MM-DD");
 
+    // NOTE: /transactions/get is legacy. New apps should use /transactions/sync — see
+    // ../../transactions, https://youtu.be/Pin0-ceDKcI, and
+    // https://plaid.com/docs/transactions/sync-migration/
     const transactionResponse = await plaidClient.transactionsGet({
       access_token: access_token,
       start_date: startDate,
@@ -324,6 +327,9 @@ webhookApp.post("/server/receive_webhook", async (req, res, next) => {
   }
 });
 
+// NOTE: INITIAL_UPDATE / HISTORICAL_UPDATE / DEFAULT_UPDATE / TRANSACTIONS_REMOVED are legacy
+// transactions webhooks. New apps should use /transactions/sync and the SYNC_UPDATES_AVAILABLE
+// webhook instead. See https://plaid.com/docs/transactions/sync-migration/
 function handleTransactionsWebhook(code, requestBody) {
   switch (code) {
     case "INITIAL_UPDATE":

--- a/webhooks/finished/server.js
+++ b/webhooks/finished/server.js
@@ -155,9 +155,9 @@ app.get("/server/transactions", async (req, res, next) => {
     const startDate = moment().subtract(30, "days").format("YYYY-MM-DD");
     const endDate = moment().format("YYYY-MM-DD");
 
-    // NOTE: /transactions/get is legacy. New apps should use /transactions/sync — see
-    // ../../transactions, https://youtu.be/Pin0-ceDKcI, and
-    // https://plaid.com/docs/transactions/sync-migration/
+    // NOTE: this works fine for the tutorial, but /transactions/get is legacy. In a production
+    // app you would fetch transactions with /transactions/sync instead — see ../../transactions,
+    // https://youtu.be/Pin0-ceDKcI, and https://plaid.com/docs/transactions/sync-migration/
     const transactionResponse = await plaidClient.transactionsGet({
       access_token: access_token,
       start_date: startDate,
@@ -327,9 +327,10 @@ webhookApp.post("/server/receive_webhook", async (req, res, next) => {
   }
 });
 
-// NOTE: INITIAL_UPDATE / HISTORICAL_UPDATE / DEFAULT_UPDATE / TRANSACTIONS_REMOVED are legacy
-// transactions webhooks. New apps should use /transactions/sync and the SYNC_UPDATES_AVAILABLE
-// webhook instead. See https://plaid.com/docs/transactions/sync-migration/
+// NOTE: these legacy transactions webhooks (INITIAL_UPDATE / HISTORICAL_UPDATE / DEFAULT_UPDATE /
+// TRANSACTIONS_REMOVED) still fire and are fine for demonstrating webhook handling here. In a
+// production app you would use /transactions/sync with the SYNC_UPDATES_AVAILABLE webhook instead.
+// See https://plaid.com/docs/transactions/sync-migration/
 function handleTransactionsWebhook(code, requestBody) {
   switch (code) {
     case "INITIAL_UPDATE":

--- a/webhooks/start/public/js/index.js
+++ b/webhooks/start/public/js/index.js
@@ -42,6 +42,7 @@ const getTransactions = async function () {
     return {
       date: t.date,
       vendor: t.name,
+      // NOTE: `category` is deprecated; prefer `personal_finance_category` (/transactions/sync).
       category: t.category[0],
       amount: `$${t.amount.toFixed(2)}`,
     };

--- a/webhooks/start/public/js/index.js
+++ b/webhooks/start/public/js/index.js
@@ -43,7 +43,7 @@ const getTransactions = async function () {
       date: t.date,
       vendor: t.name,
       // NOTE: `category` still works but is deprecated; a production app would use
-      // `personal_finance_category` (returned by /transactions/sync) instead.
+      // `personal_finance_category` instead.
       category: t.category[0],
       amount: `$${t.amount.toFixed(2)}`,
     };

--- a/webhooks/start/public/js/index.js
+++ b/webhooks/start/public/js/index.js
@@ -42,7 +42,8 @@ const getTransactions = async function () {
     return {
       date: t.date,
       vendor: t.name,
-      // NOTE: `category` is deprecated; prefer `personal_finance_category` (/transactions/sync).
+      // NOTE: `category` still works but is deprecated; a production app would use
+      // `personal_finance_category` (returned by /transactions/sync) instead.
       category: t.category[0],
       amount: `$${t.amount.toFixed(2)}`,
     };

--- a/webhooks/start/server.js
+++ b/webhooks/start/server.js
@@ -155,9 +155,9 @@ app.get("/server/transactions", async (req, res, next) => {
     const startDate = moment().subtract(30, "days").format("YYYY-MM-DD");
     const endDate = moment().format("YYYY-MM-DD");
 
-    // NOTE: /transactions/get is legacy. New apps should use /transactions/sync — see
-    // ../../transactions, https://youtu.be/Pin0-ceDKcI, and
-    // https://plaid.com/docs/transactions/sync-migration/
+    // NOTE: this works fine for the tutorial, but /transactions/get is legacy. In a production
+    // app you would fetch transactions with /transactions/sync instead — see ../../transactions,
+    // https://youtu.be/Pin0-ceDKcI, and https://plaid.com/docs/transactions/sync-migration/
     const transactionResponse = await plaidClient.transactionsGet({
       access_token: access_token,
       start_date: startDate,

--- a/webhooks/start/server.js
+++ b/webhooks/start/server.js
@@ -155,6 +155,9 @@ app.get("/server/transactions", async (req, res, next) => {
     const startDate = moment().subtract(30, "days").format("YYYY-MM-DD");
     const endDate = moment().format("YYYY-MM-DD");
 
+    // NOTE: /transactions/get is legacy. New apps should use /transactions/sync — see
+    // ../../transactions, https://youtu.be/Pin0-ceDKcI, and
+    // https://plaid.com/docs/transactions/sync-migration/
     const transactionResponse = await plaidClient.transactionsGet({
       access_token: access_token,
       start_date: startDate,


### PR DESCRIPTION
The `webhooks` and `vanilla-js-oauth` samples fetch transactions with the legacy `/transactions/get` endpoint and the deprecated `category` field, and `webhooks` also demonstrates the legacy `INITIAL_UPDATE`/`HISTORICAL_UPDATE`/`DEFAULT_UPDATE`/`TRANSACTIONS_REMOVED` webhooks. These pair with published video tutorials, so rather than rewrite the code, this adds README notes and inline comments that confirm each sample still works and teaches its intended concept (OAuth / webhook handling) while pointing production users to `/transactions/sync`, the `transactions` sample, the Transactions Sync video, and the [sync migration guide](https://plaid.com/docs/transactions/sync-migration/).

Docs-only; no behavior change.